### PR TITLE
Fix traceid validator

### DIFF
--- a/packages/opencensus-propagation-jaeger/src/jaeger-format.ts
+++ b/packages/opencensus-propagation-jaeger/src/jaeger-format.ts
@@ -22,7 +22,7 @@ import {
 } from '@opencensus/core';
 import * as crypto from 'crypto';
 import * as uuid from 'uuid';
-import { isValidSpanId, isValidTraceId } from './validators';
+import { formatTraceId, isValidSpanId, isValidTraceId } from './validators';
 
 // TRACER_STATE_HEADER_NAME is the header key used for a span's serialized
 // context.
@@ -57,7 +57,7 @@ export class JaegerFormat implements Propagation {
     const tracerStateHeaderParts = tracerStateHeader.split(':');
     if (tracerStateHeaderParts.length !== 4) return null;
 
-    const traceId = tracerStateHeaderParts[0];
+    const traceId = formatTraceId(tracerStateHeaderParts[0]);
     const spanId = tracerStateHeaderParts[1];
     const jflags = Number(
       '0x' +

--- a/packages/opencensus-propagation-jaeger/src/validators.ts
+++ b/packages/opencensus-propagation-jaeger/src/validators.ts
@@ -54,8 +54,7 @@ const compose = (...fns: ValidationFn[]): ValidationFn => {
 };
 
 /**
- * Determines if the given traceId is valid based on section 2.2.2.1 of the
- * Trace Context spec.
+ * Determines if the given traceId is valid based on https://www.jaegertracing.io/docs/1.21/client-libraries/#value
  */
 export const isValidTraceId = compose(
   isHex,
@@ -64,8 +63,7 @@ export const isValidTraceId = compose(
 );
 
 /**
- * Determines if the given spanId is valid based on section 2.2.2.2 of the Trace
- * Context spec.
+ * Determines if the given spanId is valid based on https://www.jaegertracing.io/docs/1.21/client-libraries/#value
  */
 export const isValidSpanId = compose(
   isHex,
@@ -74,8 +72,7 @@ export const isValidSpanId = compose(
 );
 
 /**
- * Determines if the given option is valid based on section 2.2.3 of the Trace
- * Context spec.
+ * Determines if the given option is valid based on https://www.jaegertracing.io/docs/1.21/client-libraries/#value
  */
 export const isValidOption = compose(
   isHex,

--- a/packages/opencensus-propagation-jaeger/src/validators.ts
+++ b/packages/opencensus-propagation-jaeger/src/validators.ts
@@ -54,12 +54,21 @@ const compose = (...fns: ValidationFn[]): ValidationFn => {
 };
 
 /**
+ * Compose a set of validation functions into a single validation call.
+ */
+const orCompose = (...fns: ValidationFn[]): ValidationFn => {
+  return (value: string) => {
+    return fns.reduce((isValid, fn) => isValid || fn(value), false);
+  };
+};
+
+/**
  * Determines if the given traceId is valid based on https://www.jaegertracing.io/docs/1.21/client-libraries/#value
  */
 export const isValidTraceId = compose(
   isHex,
   isNotAllZeros,
-  isLength(32)
+  orCompose(isLength(32), isLength(16))
 );
 
 /**
@@ -78,3 +87,13 @@ export const isValidOption = compose(
   isHex,
   isLength(2)
 );
+
+/**
+ * Formats a traceId to 64Bit or 128Bit Hex and add leading zeroes
+ */
+export const formatTraceId = (id: string) => {
+  if (id.length > 16) {
+    return ('000000000000000000000000000000' + id).substr(-32);
+  }
+  return ('000000000000000' + id).substr(-16);
+};

--- a/packages/opencensus-propagation-jaeger/test/test-jaeger-format.ts
+++ b/packages/opencensus-propagation-jaeger/test/test-jaeger-format.ts
@@ -62,6 +62,46 @@ describe('JaegerPropagation', () => {
       );
       assert.deepStrictEqual(jaegerFormat.extract(getter), spanContext);
     });
+
+    it('should format traceId for 64Bit Hex id without leading zeros', () => {
+      const spanContext = jaegerFormat.generate();
+      spanContext.traceId = '70c2f20bd65603bd';
+      const getter = helperGetter(
+        `${spanContext.traceId}:${spanContext.spanId}::${spanContext.options}`
+      );
+      assert.deepStrictEqual(jaegerFormat.extract(getter), spanContext);
+    });
+
+    it('should format traceId for 64Bit Hex id with leading zeros', () => {
+      const spanContext = jaegerFormat.generate();
+      spanContext.traceId = 'c2f20bd65603bd';
+      const compareSpanContext = spanContext;
+      compareSpanContext.traceId = '00c2f20bd65603bd';
+      const getter = helperGetter(
+        `${spanContext.traceId}:${spanContext.spanId}::${spanContext.options}`
+      );
+      assert.deepStrictEqual(jaegerFormat.extract(getter), compareSpanContext);
+    });
+
+    it('should format traceId for 128Bit Hex id without leading zeros', () => {
+      const spanContext = jaegerFormat.generate();
+      spanContext.traceId = '929985345ae64c35acddd590f13ffc82';
+      const getter = helperGetter(
+        `${spanContext.traceId}:${spanContext.spanId}::${spanContext.options}`
+      );
+      assert.deepStrictEqual(jaegerFormat.extract(getter), spanContext);
+    });
+
+    it('should format traceId for 128Bit Hex id with leading zeros', () => {
+      const spanContext = jaegerFormat.generate();
+      spanContext.traceId = '9985345ae64c35acddd590f13ffc82';
+      const compareSpanContext = spanContext;
+      compareSpanContext.traceId = '009985345ae64c35acddd590f13ffc82';
+      const getter = helperGetter(
+        `${spanContext.traceId}:${spanContext.spanId}::${spanContext.options}`
+      );
+      assert.deepStrictEqual(jaegerFormat.extract(getter), compareSpanContext);
+    });
   });
 
   describe('inject', () => {
@@ -103,6 +143,50 @@ describe('JaegerPropagation', () => {
 
       jaegerFormat.inject(setter, emptySpanContext);
       assert.deepStrictEqual(jaegerFormat.extract(getter), null);
+    });
+
+    it('should inject spancontext with 64Bit traceID', () => {
+      const spanContext = {
+        traceId: '70c2f20bd65603bd',
+        spanId: '5ba4ceca5d0edd4c',
+        options: SAMPLED_VALUE,
+      };
+      const headers: { [key: string]: string | string[] | undefined } = {};
+      const setter: HeaderSetter = {
+        setHeader(name: string, value: string) {
+          headers[name] = value;
+        },
+      };
+      const getter: HeaderGetter = {
+        getHeader(name: string) {
+          return headers[name];
+        },
+      };
+
+      jaegerFormat.inject(setter, spanContext);
+      assert.deepStrictEqual(jaegerFormat.extract(getter), spanContext);
+    });
+
+    it('should inject spancontext with 128Bit traceID', () => {
+      const spanContext = {
+        traceId: '929985345ae64c35acddd590f13ffc82',
+        spanId: '5ba4ceca5d0edd4c',
+        options: SAMPLED_VALUE,
+      };
+      const headers: { [key: string]: string | string[] | undefined } = {};
+      const setter: HeaderSetter = {
+        setHeader(name: string, value: string) {
+          headers[name] = value;
+        },
+      };
+      const getter: HeaderGetter = {
+        getHeader(name: string) {
+          return headers[name];
+        },
+      };
+
+      jaegerFormat.inject(setter, spanContext);
+      assert.deepStrictEqual(jaegerFormat.extract(getter), spanContext);
     });
   });
 


### PR DESCRIPTION
imho no easier way to allow a secondary length as the `compose` function doesnt allow binary operators to be passed in, i.e. every function passed in needs to return true on their own